### PR TITLE
add dropdown selector and give chart modification capabilities

### DIFF
--- a/app/dashboard/components/Visualizations.tsx
+++ b/app/dashboard/components/Visualizations.tsx
@@ -35,7 +35,7 @@ const Visualizations: React.FC<Props> = ({ data }: Props) => {
     <div>
       <p>Successful upload! However, we dont have any processing functions yet. Once we do, visualizations will appear here after loading</p>
       
-      <MaxGradeChart data={sportClimbs} />
+      <MaxGradeChart data={data} />
     </div>
 
   );

--- a/app/dashboard/components/charts/MaxGrade.tsx
+++ b/app/dashboard/components/charts/MaxGrade.tsx
@@ -22,7 +22,6 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
   const width: number = 700
   const height: number = 500
   const dataFilteredByClimbingType = data.filter((oneRoute: RawDataRow) => oneRoute["Route Type"] === typeOfClimbing);
-  console.log(dataFilteredByClimbingType)
   const datesByMonth = dateProcessor(dataFilteredByClimbingType)
   
   // Convenience function to pass into xScale...We could get this from datesByMonth with some more work inside the function but this makes it look simpler below
@@ -114,7 +113,7 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
   
   return (
     <div className="container">
-      <Dropdown options={["Sport", "Trad", "All"]} onChange={setTypeOfClimbing} />
+      <Dropdown options={["Sport", "Trad"]} onChange={setTypeOfClimbing} />
       <svg ref={svgRef}></svg>
     </div>
   );

--- a/app/dashboard/components/charts/MaxGrade.tsx
+++ b/app/dashboard/components/charts/MaxGrade.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, {useEffect, useRef} from "react";
-import {RawDataList} from '../../types/raw-data-from-mountain-project';
+import React, {useEffect, useRef, useState} from "react";
+import RawDataRow, {RawDataList} from '../../types/raw-data-from-mountain-project';
 import * as d3 from 'd3';
 import dateProcessor from "@/app/utils/date-grouper";
+import Dropdown from "../form-inputs/Dropdown";
 import {YDS_ARRAY} from "@/app/constants";
 
 interface Props {
@@ -16,13 +17,16 @@ interface LineData {
 }
 
 const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
+  const [typeOfClimbing, setTypeOfClimbing] = useState<string>("Sport");
   const svgRef = useRef<SVGSVGElement>(null);
   const width: number = 700
   const height: number = 500
-  const datesByMonth = dateProcessor(data)
+  const dataFilteredByClimbingType = data.filter((oneRoute: RawDataRow) => oneRoute["Route Type"] === typeOfClimbing);
+  console.log(dataFilteredByClimbingType)
+  const datesByMonth = dateProcessor(dataFilteredByClimbingType)
   
   // Convenience function to pass into xScale...We could get this from datesByMonth with some more work inside the function but this makes it look simpler below
-  const dates:(Date)[] = data
+  const dates:(Date)[] = dataFilteredByClimbingType
     .map(row => d3.timeParse("%Y-%m-%d")(row.Date))
     .filter((date): date is Date => date !== null);
 
@@ -52,13 +56,21 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
     // Does some funky react shit to grab the svg element and work with it from within the react component lifecycle
     const svg = d3.select(svgRef.current);
 
-    // Designs the canvas and the axis locations
+    // Creates the canvas upon which we can draw svg things
     svg
       .attr("width", width + margin.left + margin.right)
       .attr("height", height + margin.top + margin.bottom)
+    
     const addedMargins = margin.left + margin.right
-    let chart = svg
+
+    // If line has already been drawn and user changes dropdown menu, erase existing line. 
+    // If no line has been drawn, this does nothing
+    d3.select(".inner-chart").remove();
+    
+    // Creates an inner box which will represent the actual drawn chart. We seperate this from the svg variable because it's necessary to do so to get axis margins to work with d3
+    const chart = svg
       .append("g")
+      .attr("class", "inner-chart")
       .attr("transform", "translate(" + addedMargins + "," + margin.top + ")");
 
     // This thing takes in Date objects and converts them to x coordinates on our svg canvas
@@ -84,21 +96,25 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
       .attr("class", "y-axis")
       .call(d3.axisLeft(yScale));
 
+    // Draws the line for the chart
     chart.append("path")
       .datum(chartArray)
       .attr("fill", "none")
+      .attr("class", "chart-line")
       .attr("stroke", "steelblue")
       .attr("stroke-width", 1.5)
       .attr("d", d3.line<LineData>()
-        .x((chartArrayItem) => { return xScale(chartArrayItem.month) + 17 })
+        .x((chartArrayItem) => { return xScale(chartArrayItem.month) - xScale(chartArray[chartArray.length -1].month) })
         .y((chartArrayItem) => { return yScale(chartArrayItem.grade) as number })
       )
 
-    // need to make chart axis start at correct place...the +17 is a hack to make it work for now
-  }, [data, height, width, dates, chartArray]);
+    // it turned out the last item in the date array (which was the earliest date), was offset by negative 15 or so, skewing the chart to the left, 
+    // so we subtract it's value from the x value of every x data point and it fixes the chart. Still kind of hacky but an improvement
+  }, [data, height, width, dates, chartArray, typeOfClimbing]);
   
   return (
     <div className="container">
+      <Dropdown options={["Sport", "Trad", "All"]} onChange={setTypeOfClimbing} />
       <svg ref={svgRef}></svg>
     </div>
   );

--- a/app/dashboard/components/form-inputs/Dropdown.tsx
+++ b/app/dashboard/components/form-inputs/Dropdown.tsx
@@ -5,14 +5,20 @@ interface SelectProps {
   onChange: (selectedValue: string) => void; // Callback function when the selected value changes
 }
 
+// This input is a dropdown form element which will take an array of strings and a setState function and will allow users t
+// modify change the data source for the charts they are looking at. The options prop is an array of strings which will 
+// will need to correspond exactly to values in the data 
+// i.e. ["Sport", "Trad"] for the "Route Type" column, ["Onsight", "Flash", "Redpoint", "(etc..)"] for the "Lead Style" column) 
+
 const Dropdown: React.FC<SelectProps> = ({ options, onChange }) => {
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = event.target.value;
     onChange(selectedValue);
   };
 
+  if (!options) return null;
   return (
-    <select onChange={handleChange} defaultValue={"All"}>
+    <select onChange={handleChange} defaultValue={options[0]}>
       {options && options.map((option, index) => (
         <option key={index} value={option}>
           {option}

--- a/app/dashboard/components/form-inputs/Dropdown.tsx
+++ b/app/dashboard/components/form-inputs/Dropdown.tsx
@@ -1,0 +1,25 @@
+import React, { ChangeEvent } from 'react';
+
+interface SelectProps {
+  options: string[] | null; // List of possible strings as values for options
+  onChange: (selectedValue: string) => void; // Callback function when the selected value changes
+}
+
+const Dropdown: React.FC<SelectProps> = ({ options, onChange }) => {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = event.target.value;
+    onChange(selectedValue);
+  };
+
+  return (
+    <select onChange={handleChange} defaultValue={"All"}>
+      {options && options.map((option, index) => (
+        <option key={index} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
gives users capability to select values from a dropdown and re-render the chart from within the browser to see either trad or sport climbs...Also cleans up the logic for aligning the beginning of the chart line with the y axis a little. Still a hack, but a cleaner hack