### PR TITLE
fix alignment of chart, get rid of weird floating square, destroy annoying titles

### DIFF
--- a/app/dashboard/components/Visualizations.tsx
+++ b/app/dashboard/components/Visualizations.tsx
@@ -65,7 +65,7 @@ const Visualizations: React.FC<Props> = ({ data }: Props) => {
       <CounterTables compartmentalizedData={{sport: sportClimbs, boulders: boulders, trad: tradClimbs, TR: topRope, all: data}} />
       <Grid container spacing={5}>
         <Grid item>
-          <Card title="Onsight Chart" raised> {/*  https://github.com/mui/material-ui/issues/27846 */}
+          <Card raised> {/*  https://github.com/mui/material-ui/issues/27846 */}
             <CardHeader disableTypography
               title="Sport Climbs: Onsight Percentage"
             />
@@ -75,7 +75,7 @@ const Visualizations: React.FC<Props> = ({ data }: Props) => {
           </Card>
         </Grid>
         <Grid item>
-          <Card title="Max Grade Chart" raised>
+          <Card raised>
             <CardHeader disableTypography
               title="Max Grade Over Time"
               // subheader="Woot!" - maybe use titleTypographyProps

--- a/app/dashboard/components/charts/MaxGrade.tsx
+++ b/app/dashboard/components/charts/MaxGrade.tsx
@@ -57,8 +57,6 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
   useEffect(() => {
     if (data.length === 0) return;
     
-    
-
     // Does some funky react shit to grab the svg element and work with it from within the react component lifecycle
     const svg = d3.select(svgRef.current);
 
@@ -78,12 +76,13 @@ const MaxGradeChart: React.FC<Props> = ({data}: Props) => {
     const chart = svg
       .append("g")
       .attr("class", "inner-chart-max-grade")
-      .attr("transform", "translate(" + addedMargins + "," + margin.top + ")");
+      .attr("transform", "translate(" + 67 + "," + margin.top + ")");
 
     // For tooltip, creates tooltip as a div sibling of our svg element in the html tree. 
     // Bothsvg and tooltip sit directly under a parent div with class "chart-container-max-grade"
     const div = d3.select(".chart-container-max-grade").append("div")	
       .attr("class", "tooltip")
+      .style("opacity", "0")
 
     // This thing takes in Date objects and converts them to x coordinates on our svg canvas
     const xScale = d3


### PR DESCRIPTION
re-capitate max grade chart by adjusting alignment, remove the weird floating square at the bottom of the chart, and get rid of the titles on hover